### PR TITLE
Add Travis CI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,7 @@
+os:
+  - linux
+  - osx
+
+script:
+  - make install_deps
+  - make run

--- a/.travis.yml
+++ b/.travis.yml
@@ -9,7 +9,7 @@ env:
 
 script:
   - git submodule update --init --recursive
-  - apt install -y libprocps-dev
+  - sudo apt install -y libprocps-dev
   - bash -ex .travis-ocaml.sh
   - opam install dune
   - make install_deps

--- a/.travis.yml
+++ b/.travis.yml
@@ -3,13 +3,13 @@ sudo: required
 install: wget https://raw.githubusercontent.com/ocaml/ocaml-ci-scripts/master/.travis-ocaml.sh
 os:
   - linux
-  - osx
 
 env:
   - OCAML_VERSION=4.09
 
 script:
   - git submodule update --init --recursive
+  - apt install -y libprocps-dev
   - bash -ex .travis-ocaml.sh
   - opam install dune
   - make install_deps

--- a/.travis.yml
+++ b/.travis.yml
@@ -3,7 +3,7 @@ os:
   - osx
 
 script:
-  - sh <(curl -sL https://raw.githubusercontent.com/ocaml/opam/master/shell/install.sh) <<< $'\ny\ny'
+  - sudo sh <(curl -sL https://raw.githubusercontent.com/ocaml/opam/master/shell/install.sh) <<< $'\ny\ny'
   - opam init
   - make install_deps
   - make run

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,6 @@
 language: c
 sudo: required
-install: wget https://raw.githubusercontent.com/ocaml/ocaml-ci-scripts/master/.travis-opam.sh
+install: wget https://raw.githubusercontent.com/ocaml/ocaml-ci-scripts/master/.travis-ocaml.sh
 os:
   - linux
   - osx
@@ -10,6 +10,6 @@ env:
 
 script:
   - git submodule update --init --recursive
-  - bash -ex .travis-opam.sh
+  - bash -ex .travis-ocaml.sh
   - make install_deps
   - make run

--- a/.travis.yml
+++ b/.travis.yml
@@ -11,7 +11,5 @@ env:
 script:
   - git submodule update --init --recursive
   - bash -ex .travis-opam.sh
-  - sh <(curl -sL https://raw.githubusercontent.com/ocaml/opam/master/shell/install.sh) <<< $'\ny\ny'
-  - opam init
   - make install_deps
   - make run

--- a/.travis.yml
+++ b/.travis.yml
@@ -3,5 +3,6 @@ os:
   - osx
 
 script:
+  - sh <(curl -sL https://raw.githubusercontent.com/ocaml/opam/master/shell/install.sh)
   - make install_deps
   - make run

--- a/.travis.yml
+++ b/.travis.yml
@@ -3,6 +3,6 @@ os:
   - osx
 
 script:
-  - sh <(curl -sL https://raw.githubusercontent.com/ocaml/opam/master/shell/install.sh)
+  - sh <(curl -sL https://raw.githubusercontent.com/ocaml/opam/master/shell/install.sh) <<< $'\ny\ny'
   - make install_deps
   - make run

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,9 +1,16 @@
+language: c
+sudo: required
+install: wget https://raw.githubusercontent.com/ocaml/ocaml-ci-scripts/master/.travis-opam.sh
 os:
   - linux
   - osx
 
+env:
+  - OCAML_VERSION=4.09
+
 script:
   - git submodule update --init --recursive
+  - bash -ex .travis-opam.sh
   - sh <(curl -sL https://raw.githubusercontent.com/ocaml/opam/master/shell/install.sh) <<< $'\ny\ny'
   - opam init
   - make install_deps

--- a/.travis.yml
+++ b/.travis.yml
@@ -4,5 +4,6 @@ os:
 
 script:
   - sh <(curl -sL https://raw.githubusercontent.com/ocaml/opam/master/shell/install.sh) <<< $'\ny\ny'
+  - opam init
   - make install_deps
   - make run

--- a/.travis.yml
+++ b/.travis.yml
@@ -11,5 +11,6 @@ env:
 script:
   - git submodule update --init --recursive
   - bash -ex .travis-ocaml.sh
+  - opam install dune
   - make install_deps
   - make run

--- a/.travis.yml
+++ b/.travis.yml
@@ -3,7 +3,8 @@ os:
   - osx
 
 script:
-  - sudo sh <(curl -sL https://raw.githubusercontent.com/ocaml/opam/master/shell/install.sh) <<< $'\ny\ny'
+  - git submodule update --init --recursive
+  - sh <(curl -sL https://raw.githubusercontent.com/ocaml/opam/master/shell/install.sh) <<< $'\ny\ny'
   - opam init
   - make install_deps
   - make run


### PR DESCRIPTION
This works for the most part. You can see the failure point @ line 1082 of Travis output.

Build is currently just configured for linux however others can be added into the matrix as follows:

```yaml
os:
    - linux
    - osx
```
Some if statements will need to be added to install platform dependent snarky dependencies.

We can also add different OCaml versions into the matrix as follows:

```yaml
env:
  - OCAML_VERSION=4.09
  - OCAML_VERSION=4.08
```

Installing OCaml uses bash from [here](https://github.com/ocaml/ocaml-ci-scripts/).